### PR TITLE
Feature/board detail show

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -5,6 +5,10 @@ class BoardsController < ApplicationController
     @boards = Board.includes(:user).order(created_at: :desc).page(params[:page])
   end
 
+  def show
+    @board = Board.includes(:user).find(params[:id])
+  end
+
   def new
     @board = Board.new
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
   validates :nickname, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+
+  def own?(object)
+    id == object&.user_id
+  end
 end

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -2,7 +2,7 @@
   <div class="card h-100 shadow-sm">
     <div class="card-body">
       <h5 class="card-title">
-        <%= link_to board.title, '#', class: "text-decoration-none" %>
+        <%= link_to board.title, board_path(board), class: "text-decoration-none" %>
       </h5>
 
       <small class="text-muted d-block mb-3">
@@ -27,7 +27,7 @@
         </li>
       </ul>
 
-      <%= link_to t('.show_details'), '#', class: "btn btn-outline-primary btn-sm w-100" %>
+      <%= link_to t('.show_details'), board_path(board), class: "btn btn-outline-primary btn-sm w-100" %>
     </div>
 
     <div class="card-footer text-muted">

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="col-md-6 text-md-end">
       <%= link_to new_board_path, class: "btn btn-primary" do %>
-        <i class="bi bi-plus-circle me-1"></i>新しいカフェを投稿する
+        <i class="bi bi-plus-circle me-1"></i><%= t('.new_board') %>
       <% end %>
     </div>
   </div>

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto">
-      <h1 style="text-align:center"><%= t('.add_board_page') %></h1>
+      <h1 style="text-align:center"><%= t('.page_name') %></h1>
       <%= form_with model: @board do |f| %>
         <div class="mb-3">
           <%= f.label :title, class: "form-label" %>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,0 +1,136 @@
+<div class="container py-5">
+  <div class="row">
+    <div class="col-md-6">
+      <h1 style="text-align:center"><%= t('.page_name') %></h1>
+    </div>
+    <div class="col-lg-8 mx-auto">
+      <!-- カフェ詳細カード -->
+      <div class="card mb-4">
+        <div class="card-body">
+          <!-- タイトルと投稿者情報 -->
+          <div class="d-flex justify-content-between align-items-start mb-3">
+            <h1 class="card-title h2 mb-0"><%= @board.title %></h1>
+            <div class="text-end">
+              <% if current_user&.own?(@board) %>
+                <%= link_to '#', class: "btn btn-sm btn-outline-secondary me-1" do %>
+                  <i class="bi bi-pencil"></i><%= t('.edit') %>
+                <% end %>
+                <%= link_to '#', method: :delete, data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete') }, class: "btn btn-sm btn-outline-danger" do %>
+                  <i class="bi bi-trash"></i><%= t('.delete') %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+
+          <!-- 投稿者情報 -->
+          <div class="mb-3">
+            <small class="text-muted">
+              <%= t('.poster') %>: <%= @board.user.nickname %> | 
+              <%= t('.post_date') %>: <%= l @board.created_at, format: :long %>
+            </small>
+          </div>
+
+          <!-- 本文 -->
+          <div class="card-text mb-4">
+            <ul class="list-unstyled mb-3">
+              <li class="mb-2">
+                <strong><%= t('.address') %>:</strong> <%= @board.address %>
+              </li>
+              <li class="mb-2">
+                <strong><%= t('.nearest_station') %>:</strong> <%= @board.nearest_station %>
+              </li>
+              <li class="mb-2">
+                <strong><%= t('.opening_hours') %>:</strong> <%= @board.opening_hours.presence || t('.no_set') %>
+              </li>
+              <li class="mb-2">
+                <strong><%= t('.smoking_policy') %>:</strong> 
+                <span class="badge bg-secondary">
+                  <%= @board.smoking_policy_i18n %>
+                </span>
+              </li>
+            </ul>
+          </div>
+
+    <% if false %>
+          <!-- ブックマークボタン --
+          <div class="mb-3">
+            <%= render 'bookmarks/bookmark_button', board: @board %>
+          </div>
+        </div>
+      </div>
+      -->
+      <!--
+      <!- レビュー(コメント)セクション --
+      <div class="card">
+        <div class="card-header bg-light">
+          <h3 class="h5 mb-0">
+            <i class="bi bi-chat-dots me-2"></i>レビュー
+            <span class="badge bg-secondary"><%= @board.reviews.count %></span>
+          </h3>
+        </div>
+
+        <div class="card-body">
+          <!- レビュー投稿フォーム --
+          <% if logged_in? %>
+            <div class="mb-4">
+              <h4 class="h6 mb-3">レビューを投稿する</h4>
+              <form action="#" method="post">
+                <div class="mb-3">
+                  <textarea class="form-control" rows="3" placeholder="このカフェの感想を書いてください" required></textarea>
+                </div>
+                <div class="text-end">
+                  <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-send me-1"></i>投稿する
+                  </button>
+                </div>
+              </form>
+            </div>
+            <hr>
+          <% end %>
+
+          <!- レビュー一覧 --
+          <div class="reviews-list">
+            <% if @board.reviews.present? %>
+              <% @board.reviews.each do |review| %>
+                <div class="review-item mb-4 pb-3 border-bottom">
+                  <div class="d-flex justify-content-between align-items-start mb-2">
+                    <div>
+                      <strong><%= review.user.decorate.full_name %></strong>
+                      <small class="text-muted ms-2">
+                        <%= l review.created_at, format: :short %>
+                      </small>
+                    </div>
+                    <% if current_user&.own?(review) %>
+                      <div class="btn-group btn-group-sm">
+                        <a href="#" class="btn btn-outline-secondary">
+                          <i class="bi bi-pencil"></i>
+                        </a>
+                        <a href="#" class="btn btn-outline-danger" data-turbo-method="delete" data-turbo-confirm="削除してもよろしいですか？">
+                          <i class="bi bi-trash"></i>
+                        </a>
+                      </div>
+                    <% end %>
+                  </div>
+                  <p class="mb-0"><%= simple_format(review.body) %></p>
+                </div>
+              <% end %>
+            <% else %>
+              <div class="text-center text-muted py-4">
+                <i class="bi bi-chat-dots fs-1 d-block mb-2"></i>
+                <p>まだレビューがありません。最初のレビューを投稿してみませんか？</p>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div> -->
+    <% end %>
+
+      <!-- 戻るボタン -->
+      <div class="mt-4">
+        <%= link_to boards_path, class: "btn btn-outline-secondary" do %>
+          <i class="bi bi-arrow-left me-1"></i>一覧に戻る
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,16 +29,23 @@ ja:
       show_details: 詳細を見る
     index:
       title: カフェ一覧
-      new_board: 新規カフェ登録
+      new_board: 新しいカフェを投稿する
       no_boards: カフェが登録されていません
       board_count_info: "%{count}件のカフェ"
     show:
-      title: カフェ詳細
+      page_name: カフェ詳細
+      poster: 投稿者
+      post_date: 投稿日
+      address: 住所
+      nearest_station: 最寄駅
+      opening_hours: 営業時間
+      smoking_policy: 喫煙形態
+      no_set: 不明
       edit: 編集
       delete: 削除
       confirm_delete: 本当に削除しますか?
     new:
-      add_board_page: カフェ登録
+      page_name: カフェ登録
       title: カフェ名
       address: 住所
       nearest_station: 最寄駅

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,5 @@ Rails.application.routes.draw do
   delete "logout", to: "user_sessions#destroy"
 
   resources :users, only: %i[new create]
-  resources :boards, only: %i[index new create]
+  resources :boards, only: %i[index new create show]
 end


### PR DESCRIPTION
## 概要
CLOSES: #24 #25 
カフェ(board)について、詳細アクションおよび詳細画面の実装を行った。
将来的にカフェ詳細画面でレビューの閲覧・投稿もできるようにするため、そのためのコードも記載した。
レビュー機能のためのview部分は、`<% if false %>`によって読み込まないよう処置をした。

## 実装内容

- `config/routes.rb`のboardにshow機能のルーティングを追加。
- `app/controllers/boards_controller.rb`にshowアクションの追加。
- `app/views/boards/show.html.erb`を生成・編集。
- `app/models/user.rb`へ`own?(object)`メソッドを追加。
- `app/views/boards/_board.html.erb`の一部調整。
- `app/views/boards/index.html.erb`の一部調整。
- `app/views/boards/new.html.erb`の一部調整。
- `config/locales/views/ja.yml`によって、各表示画面の文言を調整。

## 確認方法
ブラウザで`http://localhost:3000/boards/:id`へアクセスし、カフェ詳細画面が表示されることを確認した。
