### PR TITLE
Feature/review edit destroy

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -8,9 +8,37 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def edit
+    @review = current_user.reviews.find(params[:id])
+    @board = @review.board
+  end
+
+  def update
+    @review = current_user.reviews.find(params[:id])
+
+    if @review.update(update_review_params)
+      redirect_to board_path(@review.board), success: "レビューを更新しました"
+    else
+      @board = @review.board
+      flash.now[:danger] = "レビューの更新に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    review = current_user.reviews.find(params[:id])
+    board = review.board
+    review.destroy!
+    redirect_to board_path(board), success: "レビューを削除しました", status: :see_other
+  end
+
   private
 
   def review_params
     params.require(:review).permit(:workability_rating, :comment).merge(board_id: params[:board_id])
+  end
+
+  def update_review_params
+    params.require(:review).permit(:workability_rating, :comment)
   end
 end

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,8 +1,20 @@
 <div class="card mb-2">
   <div class="card-body">
-    <div class="d-flex justify-content-between">
-      <strong><%= review.user.nickname %></strong>
-      <small class="text-muted"><%= l review.created_at, format: :short %></small>
+    <div class="d-flex justify-content-between align-items-start mb-2">
+      <div>
+        <strong><%= review.user.nickname %></strong>
+        <small class="text-muted ms-2"><%= l review.created_at, format: :short %></small>
+      </div>
+      <% if current_user&.own?(review) %>
+        <div class="d-flex gap-1">
+          <%= link_to edit_review_path(review), class: "btn btn-sm btn-outline-secondary" do %>
+            <i class="bi bi-pencil"></i><%= t('defaults.edit') %>
+          <% end %>
+          <%= link_to review_path(review), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') }, class: "btn btn-sm btn-outline-danger" do %>
+            <i class="bi bi-trash"></i><%= t('defaults.delete') %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
     <div class="my-2">
       <span class="text-warning">

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,34 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-8 mx-auto">
+      <h1 style="text-align:center">レビューの編集</h1>
+      
+      <div class="card mb-3">
+        <div class="card-body">
+          <h5 class="card-title"><%= @board.title %></h5>
+          <p class="text-muted"><%= @board.address %></p>
+        </div>
+      </div>
+
+      <%= form_with model: @review, url: review_path(@review), method: :patch do |f| %>
+        <%#= render 'shared/error_messages', object: f.object %>
+        
+        <div class="mb-3">
+          <%= f.label :workability_rating, "作業のしやすさ", class: "form-label" %>
+          <%= f.select :workability_rating, (1..5).to_a, {}, class: "form-select" %>
+        </div>
+        
+        <div class="mb-3">
+          <%= f.label :comment, "コメント", class: "form-label" %>
+          <%= f.text_area :comment, class: "form-control", rows: 5 %>
+        </div>
+        
+        <%= f.submit class: "btn btn-primary" %>
+      <% end %>
+      
+      <div class='text-center mt-3'>
+        <%= link_to "詳細に戻る", board_path(@board) %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,6 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   resources :boards, only: %i[index new create show edit update destroy] do
-    resources :reviews, only: %i[create edit destroy], shalow: true
+    resources :reviews, only: %i[create edit update destroy], shallow: true
   end
 end


### PR DESCRIPTION
## 概要
CLOSES: #40 #41 #42
レビュー機能に、編集・削除機能を実装した。
編集機能について、当初の予定を変更して、編集画面を新規作成し持たせた。
今回は投稿・削除機能について、非同期化は行わなかった。

## 実装内容

- `config/routes.rb`にedit, update, destroyをルーティング。
- `app/controllers/reviews_controller.rb`にルーティングされたアクションをそれぞれ追加。
- `app/views/reviews/_review.html.erb`に、編集アイコン、削除アイコンをそれぞれ追加。
- `app/views/reviews/edit.html.erb`を生成・編集。

## 確認方法
ブラウザで`http://localhost:3000/boards/:id`へアクセスし、カフェ詳細画面がレビューが削除できるか確認した。
その後、`http://localhost:3000/reviews/:id/edit`にて、自分のレビューが編集できるか確認した。