### PR TITLE
Fix: デプロイの環境設定とヘッダーの修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,7 +10,7 @@
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
       <ul class='navbar-nav ms-auto main-nav align-items-center'>
         <li class='nav-item'>
-          <%= link_to t('header.board_index'), '#', class: 'nav-link' %>
+          <%= link_to t('header.board_index'), boards_path, class: 'nav-link' %>
         </li>
         
         <li class='nav-item'>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   # config.require_master_key = true
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  # config.public_file_server.enabled = false
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
## 概要
デプロイ時に静的ファイルが読み込まれていないため、`config/environments/production.rb`を修正。
修正内容は以下の通り。
 `# config.public_file_server.enabled = false`
 => `config.public_file_server.enabled = true`

`app/views/shared/_header.html.erb`のカフェ一覧パスが'#'になっていたのを修正。